### PR TITLE
Page Viewer Control

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,6 @@ description: GitHub-flavored docs theme for Jekyll
 theme: null
 
 edit: true
-addons_branch: true
 
 addons:
   - github
@@ -14,7 +13,7 @@ addons:
   - analytics
 
 copyright:
-  revision: true
+  since:
 
 readme_index:
   with_frontmatter: true
@@ -27,6 +26,22 @@ plugins:
   - jekyll-avatar
   - jekyll-mentions
 
+# more control for page viewer
+viewer:
+  theme_addons: true
+  translations: true
+  analytics: true
+  github:
+    homepage: true
+    download: true
+    issues: true
+    branch: true
+    commit: true
+  copyright:
+    copyright: true
+    time: true
+    author: true
+
 exclude:
   - Makefile
   - CNAME
@@ -38,3 +53,5 @@ exclude:
   - package.json
   - package-lock.json
   - jekyll-rtd-theme.gemspec
+
+

--- a/_includes/addons.liquid
+++ b/_includes/addons.liquid
@@ -1,17 +1,20 @@
 <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
         <span class="fa fa-book"> {{ site.title }}</span>
-        {% if site.addons_branch and site.github_metadata != false %}v: {{ branch }}{% endif %}
+        {% if site.viewer.github.branch and site.github_metadata != false %}v: {{ branch }}{% endif %}
         <span class="fa fa-caret-down"></span>
     </span>
     <div class="rst-other-versions">
-        {%- assign items = site.addons | default: addons -%}
-        {% for item in items -%}
-            {%- if addons contains item -%}
-                {% include addons/{{ item }}.liquid %}
-            {%- endif -%}
-        {% endfor -%}
+        {% include addons/github.liquid %}
+        {%- if site.viewer.translations -%} {% include addons/i18n.liquid %} {%- endif -%}
+        {%- if site.viewer.theme_addons -%} {% include addons/plugins.liquid %} {%- endif -%}
+        {%- comment -%}
+            site analytics will be always processed no matter whether it's ON or OFF,
+            it only matters to show or hide the info.
+        {%- endcomment -%}
+        {% include addons/analytics.liquid %}
         <hr>
+
         <small>
             <span>
                 Built with

--- a/_includes/addons/analytics.liquid
+++ b/_includes/addons/analytics.liquid
@@ -1,10 +1,12 @@
 <dl>
+    {%- if site.viewer.analytics -%} 
     <dt>{{ __statistics }}</dt>
     <dd>
         <a href="https://github.com/rundocs/analytics" target="_blank">
             {{ __total_visits }} <span id="counter"><span class="progress"></span></span> <i class="fa fa-eye"></i>
         </a>
     </dd>
+    {%- endif -%}
 </dl>
 
 <script>

--- a/_includes/addons/github.liquid
+++ b/_includes/addons/github.liquid
@@ -1,6 +1,8 @@
-<dl>
-    <dt>{{ __github }}</dt>
-    <dd><a href="{{ repository_url }}"><i class="fa fa-github"></i> {{ __homepage }}</a></dd>
-    <dd><a href="{{ zip_url }}"><i class="fa fa-download"></i> {{ __download }}</a></dd>
-    <dd><a href="{{ issues_url }}"><i class="fa fa-question-circle-o"></i> {{ __issues }}</a></dd>
-</dl>
+{%- if site.viewer.github.homepage or site.viewer.github.download or site.viewer.github.issues or site.viewer.github.branch -%}
+    <dl>
+        <dt>{{ __github }}</dt>
+        {%- if site.viewer.github.homepage -%} <dd><a href="{{ repository_url }}"><i class="fa fa-github"></i> {{ __homepage }}</a></dd> {%- endif -%}
+        {%- if site.viewer.github.download -%} <dd><a href="{{ zip_url }}"><i class="fa fa-download"></i> {{ __download }}</a></dd> {%- endif -%}
+        {%- if site.viewer.github.issues -%} <dd><a href="{{ issues_url }}"><i class="fa fa-question-circle-o"></i> {{ __issues }}</a></dd> {%- endif -%}
+    </dl>
+{%- endif -%}

--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -14,23 +14,25 @@
         </div>
     {%- endif -%}
     <hr>
-    {%- if site.copyright -%}
-        <div role="contentinfo" class="copyright">
-            <p>
-                <i class="fa fa-copyright"></i> {{ __copyright }}
-                {% if site.copyright.since -%}
+
+    <div role="contentinfo" class="copyright">
+        <p>
+            {%- if site.viewer.copyright.copyright %} <i class="fa fa-copyright"></i> {{ __copyright }} {%- endif -%}
+            {% if site.viewer.copyright.time %}
+                {% if site.copyright.since %}
                     {{ site.copyright.since | append: "-" }}
                 {%- endif -%}
                 {{ site.time | date: "%Y" }},
-                {{ author }}
-                {% if site.copyright.revision and site.github_metadata != false -%}
-                    <span class="commit">
-                        {{ __revision }} <code>{{ commit }}</code>
-                    </span>
-                {%- endif -%}
-            </p>
-        </div>
-    {%- endif -%}
+            {%- endif -%}
+            {% if site.viewer.copyright.author %} {{ author }} {%- endif -%}
+            {% if site.viewer.github.commit and site.github_metadata != false %}
+                <span class="commit">
+                    {{ __revision }} <code>{{ commit }}</code>
+                </span>
+            {%- endif -%}
+        </p>
+    </div>
+
     <div role="contentinfo" class="copyright rundocs">
         <p>Powered by <a href="https://rundocs.io">rundocs.io</a> using the jekyll docs theme <a href="https://rundocs.github.io/jekyll-rtd-theme">jekyll-rtd-theme</a></p>
     </div>


### PR DESCRIPTION
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Repo settings
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome (version: 83.0.4103.116)
- [ ] Firefox
- [ ] Safari
- [x] Edge (version: 44.18362.449.0)
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [x] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.


**Convincing Reason**
- Inside original code, it has the `boolean` parameter for View Control Option: `site.addons_branch` (Control to show/hide the lower-left folded window's plugins) & `site.copyright.revision` (Control to show/hide Copyright information in the footer bar), however, they are not enough, more options are needed.

- Likewise, for the built-in plugins, user can have the options to show/hide their `Github` & `Translations` & `Statistics` information just like the `site.addons_branch` did.

- Each Copyright information, like `Copyright` & `Year` & `Author` & `Commit`, in the footer bar can be specifically and individually hided, which will be extremely useful when personal website is constructed.

- For branch information, `[gh-pages]`, this information only works for the site-owner to show which branch is running, however, for visitors, it maybe distracting or confusing when referring to the document.

- For `translations`, they are apparent in web content, no needing to show it again.

- For `Statistics`, it might be nice to have an option to hide this kind of information, especially for the self-enjoying site. The thing to note is, the count is always running, the option only works to show or hide it, this option will not influence the accumulating data.

- Configuration file `_config.yml` will become more clear & meaningful, it is as its meaning listing what they are.

- Still in `_config.yml`, the omitting option `copyright.since` is added






