### PR TITLE
Fix Footer Copyright Bug

### DIFF
--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -19,20 +19,16 @@
     {%- if site.copyright -%}
         <div role="contentinfo" class="copyright">
             <p>
-                {% if site.copyright.since or site.copyright.revision -%}
-                    <i class="fa fa-copyright"></i> {{ __copyright }}
-                    {% if site.copyright.since -%}
-                        {{ site.copyright.since | append: "-" }}
-                    {%- endif -%}
-                    {{ site.time | date: "%Y" }},
-                    {{ author }}
-                    {% if site.copyright.revision and site.github_metadata != false -%}
-                        <span class="commit">
-                            {{ __revision }} <code>{{ commit }}</code>
-                        </span>
-                    {%- endif -%}
-                {%- else -%}
-                    {{ site.copyright }}
+                <i class="fa fa-copyright"></i> {{ __copyright }}
+                {% if site.copyright.since -%}
+                    {{ site.copyright.since | append: "-" }}
+                {%- endif -%}
+                {{ site.time | date: "%Y" }},
+                {{ author }}
+                {% if site.copyright.revision and site.github_metadata != false -%}
+                    <span class="commit">
+                        {{ __revision }} <code>{{ commit }}</code>
+                    </span>
                 {%- endif -%}
             </p>
         </div>


### PR DESCRIPTION
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Repo settings
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome (version: 84.0.4147.105)
- [x] Firefox (version: 67.0 Firefox Quantum for Ubuntu)
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.


### Reproduce

In default `_config.yml` file set:
```
copyright:
  revision: false
```
then, compile, in the built website footer bar, it will show information 
```
{"revision"=>false}
```
### Bug Reason
Following the top settings, the **copyright** metadata will be set:
```
site.copyright             --> true
site.copyright.since       --> false
site.copyright.revision    --> false
```
Since both `site.copyright.since` and `site.copyright.revision` are set to `false`, so the `YEAR` and `AUTHOR` info will be hided, thus the `site.copyright` will be evaluated, however, this evaluation is the metadata from `liquid`, it is not the correct information that we want.

### Bug Fix
**Consideration**
- If user sets the `copyright` metadata, if by default means the `YEAR` & `AUTHOR` will be shown.
- If user wants to hide their `revision` info, then this info should be hided
- If user does not want to show their copyright info, the the overall metadata `site.copyright` can be chosen, to set to `false`

The fix meets those considerations.



