### PR TITLE
Fixed a bug in links.liquid

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ debug:
   in_develop: true
   extension: true
 
-# rtl: true
+rtl: true
 
 readme_index:
   with_frontmatter: true

--- a/_config.yml
+++ b/_config.yml
@@ -4,13 +4,13 @@ description: Opinionated github flavored standard document theme for open source
 
 theme: null
 
-debug:
-  compress: true
-  dist: false
-  in_develop: true
-  extension: true
+#debug:
+#  compress: true
+#  dist: false
+#  #in_develop: true
+#  extension: true
 
-rtl: true
+# rtl: false
 
 readme_index:
   with_frontmatter: true

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ debug:
   in_develop: true
   extension: true
 
-rtl: true
+# rtl: true
 
 readme_index:
   with_frontmatter: true

--- a/_includes/node/links.liquid
+++ b/_includes/node/links.liquid
@@ -17,13 +17,13 @@
 {% if site.rtl == true %}
     {% comment %} theme {% endcomment %}
     {% if site.debug.in_develop == true %}
-        <link rel="stylesheet" href="/assets/css/theme-rtl.css">
+        <link rel="stylesheet" href="{{ '/assets/css/theme-rtl.css' | relative_url }}">
     {% else %}
         <link rel="stylesheet" href="{{ cdn }}/assets/css/theme-rtl{% if site.debug.dist != false %}.min{% endif %}.css">
     {% endif %}
 {% else %}
     {% if site.debug.in_develop == true %}
-        <link rel="stylesheet" href="/assets/css/theme-ltr.css">
+        <link rel="stylesheet" href="{{ '/assets/css/theme-ltr.css' | relative_url }}">
     {% else %}
         {% comment %} theme {% endcomment %}
         <link rel="stylesheet" href="{{ cdn }}/assets/css/theme-ltr{% if site.debug.dist != false %}.min{% endif %}.css">


### PR DESCRIPTION
Fixed a bug in `links.liquid` that led to broken css links when in_develop option is set.